### PR TITLE
v1.0.2 fix bug on Windows where chrome can be installed in different location rather than hard-coded

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -4,7 +4,7 @@ CALL mvn clean package
 
 if not exist out mkdir out
 del BitHeroes.jar >nul 2>&1
-echo F|xcopy target\ReRun-*-jar-with-dependencies.jar BitHeroes.jar /Y
+echo F|xcopy target\BitHeroes-*-jar-with-dependencies.jar BitHeroes.jar /Y
 if not exist user-config.properties echo. 2>user-config.properties
 
 rem Generating mini client

--- a/client.bat
+++ b/client.bat
@@ -1,1 +1,2 @@
+del mini-game-on-chrome.bat >nul 2>&1
 java -jar BitHeroes.jar client

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>bh.bot</groupId>
     <artifactId>BitHeroes</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <build>
         <resources>

--- a/release.sh
+++ b/release.sh
@@ -47,6 +47,9 @@ telegram.channel-id=
 # Tolerant
 tolerant.position=50
 tolerant.color=0
+
+# Google Chrome path, for Windows only
+external.application.chrome.path=C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
 EOF
 
 # Copy files for mini client

--- a/release.sh
+++ b/release.sh
@@ -49,7 +49,7 @@ tolerant.position=50
 tolerant.color=0
 
 # Google Chrome path, for Windows only
-external.application.chrome.path=C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
+external.application.chrome.path=C:\\\\Program Files (x86)\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe
 EOF
 
 # Copy files for mini client

--- a/src/main/java/bh/bot/app/GenMiniClient.java
+++ b/src/main/java/bh/bot/app/GenMiniClient.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static bh.bot.common.Log.err;
 import static bh.bot.common.Log.info;
+import static bh.bot.common.utils.StringUtil.isBlank;
 
 public class GenMiniClient extends AbstractApplication {
     private static final File chromeUserDir = new File("chrome-user-dir");
@@ -23,8 +24,8 @@ public class GenMiniClient extends AbstractApplication {
         String scriptFileName = String.format("mini-game-on-chrome.%s", Configuration.OS.isWin ? "bat" : "sh");
         if (errMsg != null)
         {
-            err("Unable to generate %s with error:", scriptFileName);
-            err("  %s", errMsg);
+            err("ERROR: Unable to generate mini-client!!!");
+            err("Error message: %s", errMsg);
             info("To be able to use mini game client (using Google Chrome), the following conditions must be met:");
             info(" 1. Google Chrome must be installed");
             info(" 2. You can play Bit Heroes game at https://www.kongregate.com/games/Juppiomenz/bit-heroes");
@@ -69,7 +70,38 @@ public class GenMiniClient extends AbstractApplication {
                 chromeArgs.add("--window-position=0,0");
                 chromeArgs.add(String.format("\"--app=file://%s\"", pathIndex.toAbsolutePath().toString()));
             } else if (Configuration.OS.isWin) {
-                app = "\"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\"";
+				final String keyChromePath = "external.application.chrome.path";
+				final String defaultChromePath = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe";
+				String chromePath = Configuration.read(keyChromePath);
+				if (isBlank(chromePath)) {
+					info("Missing configuration of Google Chrome path (key %s), going to set to use default path: %s", keyChromePath, defaultChromePath);
+					chromePath = defaultChromePath;
+				}
+				
+				if (!(new File(chromePath)).exists()) {
+					err("ERROR: Chrome not found");
+					info("Can not find Google Chrome at provided path %s", chromePath);
+					info("Please provide a correct path to chrome.exe into key '%s' on user-config.properties file", keyChromePath);
+					info("To get it, you can do this:");
+					info("1. Right click on Google Chrome shortcut");
+					info("2. Select Properties");
+					info("3. Copy value of Target line");
+					info("4. Transfrom the value to a correct format. For example:");
+					info("  - Input value is:");
+					info("    \"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\"");
+					info("    (with the double quotes)");
+					info("  - Should be translated into:");
+					info("    C:\\\\Program Files (x86)\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe");
+					info("    (remove the double quotes and double the back slashes)");
+					info("5. Fill the translated path into key '%s' of the user-config.properties file", keyChromePath);
+					info("    Example:");
+					info("%s=C:\\\\Program Files (x86)\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe", keyChromePath);
+					info("6. Save the file user-config.properties after modified");
+					info("7. Run script '.\\client.bat' to generate mini-client");
+					System.exit(1);
+				}
+				
+                app = String.format("\"%s\"", chromePath);
 				chromeArgs.add(String.format("\"--user-data-dir=%s\"", chromeUserDir.getAbsolutePath()));
 				chromeArgs.add("--window-size=820,565");
 				chromeArgs.add("--window-position=0,0");

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -38,3 +38,7 @@ offset.fishing.buttons.cast-sp.y=462
 # Fishing#Catch
 offset.fishing.buttons.catch-sp.x=360
 offset.fishing.buttons.catch-sp.y=462
+
+# External
+# Google Chrome path, for Windows only
+external.application.chrome.path=C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe


### PR DESCRIPTION
Previous: Chrome's path was hard-coded with value C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
Now: User able to custom Chrome path by modify key external.application.chrome.path on user-config.properties file