### PR TITLE
imp: Allow instance ID to come from env keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>bh.bot</groupId>
 	<artifactId>99bot</artifactId>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 
 	<dependencies>
 		<dependency>

--- a/src/main/java/bh/bot/common/Telegram.java
+++ b/src/main/java/bh/bot/common/Telegram.java
@@ -20,7 +20,7 @@ public class Telegram {
     //
     private static final String channelId = Configuration.getFromConfigOrEnv("telegram.channel-id", "TELEGRAM_BH_CHANNEL");
     //
-    private static final String _instanceId = Configuration.read("telegram.instance-id");
+    private static final String _instanceId = Configuration.getFromConfigOrEnv("telegram.instance-id", "TELEGRAM_INSTANCE_ID");
     private static final String instanceId = StringUtil.isBlank(_instanceId) ? "" : String.format(":%s", _instanceId.trim());
     //
     private static boolean isDisabled = isBlank(token) || isBlank(channelId);


### PR DESCRIPTION
This allows the instance ID to come from the environment, making it easier to provide a unique instance ID for each character by changing the environment instead of the file.