### PR TITLE
Upgrade afk

### DIFF
--- a/src/main/java/bh/bot/Main.java
+++ b/src/main/java/bh/bot/Main.java
@@ -391,6 +391,7 @@ public class Main {
 		li.eWorldBoss = usingFlagPatterns.stream().anyMatch(x -> x instanceof FlagDoWorldBoss);
 		li.eRaid = usingFlagPatterns.stream().anyMatch(x -> x instanceof FlagDoRaid);
 		li.eInvasion = usingFlagPatterns.stream().anyMatch(x -> x instanceof FlagDoInvasion);
+		li.eQuest = usingFlagPatterns.stream().anyMatch(x -> x instanceof FlagDoQuest);
 		li.eExpedition = usingFlagPatterns.stream().anyMatch(x -> x instanceof FlagDoExpedition);
 		li.eGvg = usingFlagPatterns.stream().anyMatch(x -> x instanceof FlagDoGvG);
 		li.eTrials = usingFlagPatterns.stream().anyMatch(x -> x instanceof FlagDoTrials);
@@ -513,7 +514,7 @@ public class Main {
 	public static void warningSupport() {
 		try {
 			Rad.pWarn(20,"Only support English interface");
-			Rad.pWarn(50,"Only support screen scale 100%% (original, no scale) otherwise bot will working wrongly");
+			Rad.pWarn(50,"Only support screen scale 100%% (original, no scale) otherwise bot will malfunction");
 		} catch (Throwable t) {
 			// ignore
 		}

--- a/src/main/java/bh/bot/app/AbstractApplication.java
+++ b/src/main/java/bh/bot/app/AbstractApplication.java
@@ -20,6 +20,8 @@ import bh.bot.common.types.tuples.Tuple4;
 import bh.bot.common.utils.*;
 import bh.bot.common.utils.ColorizeUtil.Cu;
 import bh.bot.common.utils.InteractionUtil.Keyboard;
+
+import com.sun.jna.platform.DesktopWindow;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinNT;
@@ -1556,7 +1558,7 @@ public abstract class AbstractApplication {
 		err("Please launch script '%s' and follow instruction", scriptFileName("setting"));
 	}
 
-	private HWND gameWindowHwndByJna = null;
+	private DesktopWindow gameWindowHwndByJna = null;
 
 	protected void doCheckGameScreenOffset(AtomicBoolean masterSwicth) {
 		debug("doCheckGameScreenOffset");

--- a/src/main/java/bh/bot/common/jna/AbstractJna.java
+++ b/src/main/java/bh/bot/common/jna/AbstractJna.java
@@ -2,6 +2,7 @@ package bh.bot.common.jna;
 
 import static bh.bot.common.Log.err;
 
+import com.sun.jna.platform.DesktopWindow;
 import com.sun.jna.platform.win32.WinDef.HWND;
 
 import bh.bot.common.exceptions.NotSupportedException;
@@ -20,12 +21,12 @@ public abstract class AbstractJna implements IJna {
     protected abstract void internalTryToCloseGameWindow() throws Exception;
     
     @Override
-    public void setGameWindowOnTop(HWND hwnd) {
+    public void setGameWindowOnTop(DesktopWindow desktopWindow) {
     	throw new NotSupportedException("Method setGameWindowOnTop has not been implemented for class " + this.getClass().getSimpleName());
     }
     
     @Override
-    public boolean resizeWindowToSupportedResolution(HWND hwnd, int w, int h) {
+    public boolean resizeWindowToSupportedResolution(DesktopWindow desktopWindow, int w, int h) {
     	throw new NotSupportedException("Method resizeWindowToSupportedResolution has not been implemented for class " + this.getClass().getSimpleName());
     }
     

--- a/src/main/java/bh/bot/common/jna/AbstractLinuxJna.java
+++ b/src/main/java/bh/bot/common/jna/AbstractLinuxJna.java
@@ -6,6 +6,8 @@ import bh.bot.common.types.ScreenResolutionProfile;
 import bh.bot.common.types.tuples.Tuple2;
 import bh.bot.common.types.tuples.Tuple4;
 import bh.bot.common.utils.StringUtil;
+
+import com.sun.jna.platform.DesktopWindow;
 import com.sun.jna.platform.win32.WinDef;
 
 import java.awt.*;
@@ -20,82 +22,8 @@ import static bh.bot.common.Log.*;
 
 public abstract class AbstractLinuxJna extends AbstractJna {
     @Override
-    public WinDef.HWND getGameWindow(Object... args) {
+    public DesktopWindow getGameWindow(Object... args) {
         return null;
-    }
-
-    @Override
-    public Tuple4<Boolean, String, Rectangle, Offset> locateGameScreenOffset(
-            WinDef.HWND hwnd, ScreenResolutionProfile screenResolutionProfile) {
-        if (hwnd != null)
-            throw new IllegalArgumentException("hwnd");
-        try {
-            Tuple2<Boolean, List<String>> prcResult = startProcess("ps", "-ao", "pid:1,command:1");
-            if (!prcResult._1)
-                return new Tuple4<>(false, "Failure at grep mini-client info from chrome processes", null, null);
-            List<String> psOutput = prcResult._2.stream()
-                    .filter(x -> x.contains("chrome") && x.contains("bh-client/index"))
-                    .collect(Collectors.toList());
-            if (psOutput.size() != 1)
-                return new Tuple4<>(false, "Unacceptable result from ps command", null, null);
-            String[] spl = psOutput.get(0).split(" ", 2);
-            if (spl.length != 2)
-                throw new InvalidDataException("Output of ps command has invalid format: %s", psOutput);
-            int pid;
-            try {
-                pid = Integer.parseInt(spl[0]);
-            } catch (NumberFormatException ex3) {
-                throw new InvalidDataException("Failure on parsing PID from ps command: %s", psOutput);
-            }
-            prcResult = startProcess("xdotool", "search", "--pid", String.valueOf(pid), "getwindowgeometry");
-            if (!prcResult._1)
-                return new Tuple4<>(false, "Failure at grep window id of chrome processes from xdotool", null, null);
-            if (prcResult._2.size() < 1) {
-                return new Tuple4<>(false, "Unacceptable result from xdotool command", null, null);
-            }
-
-            for (String xdoOutput : prcResult._2) {
-                int windowId;
-                try {
-                    windowId = Integer.parseInt(xdoOutput);
-                } catch (NumberFormatException ex3) {
-                    err("Failure on parsing window id from output from xdotool command: %s", xdoOutput);
-                    continue;
-                }
-
-                prcResult = startProcess("xwininfo", "-id", String.valueOf(windowId));
-                if (!prcResult._1) {
-                    err("Failure at grep window info from xwininfo for %d", windowId);
-                    continue;
-                }
-
-                List<String> xwiOutput = prcResult._2;
-                if (xwiOutput.stream().noneMatch(x -> x.contains("Bit Heroes"))) {
-                    debug("%d is not mini-client", windowId);
-                    continue;
-                }
-                Optional<String> xL = xwiOutput.stream().filter(x -> x.contains("Absolute upper-left X:")).findFirst();
-                Optional<String> yL = xwiOutput.stream().filter(x -> x.contains("Absolute upper-left Y:")).findFirst();
-
-                if (!xL.isPresent() || !yL.isPresent())
-                    throw new InvalidDataException("Unable to locate X and Y from output of xwininfo (%s)", String.join(", ", xwiOutput));
-
-                int x, y;
-                try {
-                    x = parseXOrYValue(xL.get().trim());
-                    y = parseXOrYValue(yL.get().trim());
-                } catch (IllegalArgumentException ex4) {
-                    return new Tuple4<>(false, ex4.getMessage(), null, null);
-                }
-
-                return new Tuple4<>(true, null, null, new Offset(x, y));
-            }
-
-            return new Tuple4<>(false, "Failure at grep window info from xwininfo", null, null);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return new Tuple4<>(false, "Error occurs: " + ex.getMessage(), null, null);
-        }
     }
 
     private int parseXOrYValue(String raw) {

--- a/src/main/java/bh/bot/common/jna/AbstractMacOSJna.java
+++ b/src/main/java/bh/bot/common/jna/AbstractMacOSJna.java
@@ -1,4 +1,5 @@
 package bh.bot.common.jna;
 
 public abstract class AbstractMacOSJna extends AbstractLinuxJna {
+    
 }

--- a/src/main/java/bh/bot/common/jna/AbstractWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/AbstractWindowsJna.java
@@ -2,9 +2,8 @@ package bh.bot.common.jna;
 
 import java.awt.Rectangle;
 
+import com.sun.jna.platform.DesktopWindow;
 import com.sun.jna.platform.win32.User32;
-import com.sun.jna.platform.win32.WinDef.HWND;
-import com.sun.jna.platform.win32.WinDef.RECT;
 
 import bh.bot.common.OS;
 import bh.bot.common.exceptions.NotSupportedException;
@@ -19,19 +18,10 @@ public abstract class AbstractWindowsJna extends AbstractJna {
 	}
     
     @Override
-    public Rectangle getRectangle(HWND hwnd) {
-    	if (hwnd == null)
+    public Rectangle getRectangle(DesktopWindow desktopWindow) {
+    	if (desktopWindow == null)
     		return null;
     	
-		final RECT lpRectW = new RECT();
-		if (!user32.GetWindowRect(hwnd, lpRectW))
-			return null;
-
-		return new Rectangle(
-			lpRectW.left, 
-			lpRectW.top, 
-			Math.abs(lpRectW.right - lpRectW.left),
-			Math.abs(lpRectW.bottom - lpRectW.top)
-		);
+		return desktopWindow.getLocAndSize();
     }
 }

--- a/src/main/java/bh/bot/common/jna/IJna.java
+++ b/src/main/java/bh/bot/common/jna/IJna.java
@@ -3,16 +3,16 @@ package bh.bot.common.jna;
 import bh.bot.common.types.Offset;
 import bh.bot.common.types.ScreenResolutionProfile;
 import bh.bot.common.types.tuples.Tuple4;
-import com.sun.jna.platform.win32.WinDef.HWND;
 
+import com.sun.jna.platform.DesktopWindow;
 import java.awt.*;
 
 public interface IJna {
-	HWND getGameWindow(Object...args);
-	Rectangle getRectangle(HWND hwnd);
-	Tuple4<Boolean, String, Rectangle, Offset> locateGameScreenOffset(HWND hwnd, ScreenResolutionProfile screenResolutionProfile);
+	DesktopWindow getGameWindow(Object...args);
+	Rectangle getRectangle(DesktopWindow desktopWindow);
+	Tuple4<Boolean, String, Rectangle, Offset> locateGameScreenOffset(DesktopWindow desktopWindow, ScreenResolutionProfile screenResolutionProfile);
 	void tryToCloseGameWindow();
-	void setGameWindowOnTop(HWND hwnd);
-	boolean resizeWindowToSupportedResolution(HWND hwnd, int w, int h);
+	void setGameWindowOnTop(DesktopWindow desktopWindow);
+	boolean resizeWindowToSupportedResolution(DesktopWindow desktopWindow, int w, int h);
 	boolean isSupportResizeWindow();
 }

--- a/src/main/java/bh/bot/common/jna/MiniClientLinuxJna.java
+++ b/src/main/java/bh/bot/common/jna/MiniClientLinuxJna.java
@@ -1,8 +1,11 @@
 package bh.bot.common.jna;
 
-import bh.bot.common.exceptions.NotImplementedException;
+import bh.bot.common.types.Offset;
+import bh.bot.common.types.ScreenResolutionProfile;
 import bh.bot.common.types.tuples.Tuple2;
-import com.sun.jna.platform.win32.WinDef.HWND;
+import bh.bot.common.types.tuples.Tuple4;
+
+import com.sun.jna.platform.DesktopWindow;
 
 import java.awt.*;
 import java.util.List;
@@ -12,8 +15,11 @@ import static bh.bot.common.Log.debug;
 
 public class MiniClientLinuxJna extends AbstractLinuxJna {
     @Override
-    public Rectangle getRectangle(HWND hwnd) {
-        throw new NotImplementedException("MiniClientLinuxJna::getRectangle");
+    public Rectangle getRectangle(DesktopWindow desktopWindow) {
+        if (desktopWindow == null) {
+            return null;
+        }
+        return desktopWindow.getLocAndSize();
     }
 
     @Override
@@ -42,5 +48,11 @@ public class MiniClientLinuxJna extends AbstractLinuxJna {
                     "kill", "-9", String.valueOf(pid)
             }).start().waitFor();
         }
+    }
+
+    @Override
+    public Tuple4<Boolean, String, Rectangle, Offset> locateGameScreenOffset(DesktopWindow desktopWindow, ScreenResolutionProfile screenResolutionProfile) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'locateGameScreenOffset'");
     }
 }

--- a/src/main/java/bh/bot/common/jna/MiniClientMacOsJna.java
+++ b/src/main/java/bh/bot/common/jna/MiniClientMacOsJna.java
@@ -1,6 +1,11 @@
 package bh.bot.common.jna;
 
 import bh.bot.common.exceptions.NotImplementedException;
+import bh.bot.common.types.Offset;
+import bh.bot.common.types.ScreenResolutionProfile;
+import bh.bot.common.types.tuples.Tuple4;
+
+import com.sun.jna.platform.DesktopWindow;
 import com.sun.jna.platform.win32.WinDef.HWND;
 
 import java.awt.*;
@@ -9,12 +14,21 @@ import static bh.bot.common.Log.warn;
 
 public class MiniClientMacOsJna extends AbstractMacOSJna {
 	@Override
-	public Rectangle getRectangle(HWND hwnd) {
-		throw new NotImplementedException("MiniClientMacOsJna::getRectangle");
+	public Rectangle getRectangle(DesktopWindow desktopWindow) {
+		if (desktopWindow == null) {
+            return null;
+        }
+        return desktopWindow.getLocAndSize();
 	}
 
 	@Override
 	protected void internalTryToCloseGameWindow() {
 		warn("tryToCloseGameWindow: This feature is not yet implemented for mini-client on MacOS");
+	}
+
+	@Override
+	public Tuple4<Boolean, String, Rectangle, Offset> locateGameScreenOffset(DesktopWindow desktopWindow, ScreenResolutionProfile screenResolutionProfile) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Unimplemented method 'locateGameScreenOffset'");
 	}
 }

--- a/src/main/java/bh/bot/common/jna/MiniClientWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/MiniClientWindowsJna.java
@@ -27,7 +27,7 @@ public class MiniClientWindowsJna extends AbstractWindowsJna {
 		for (int i = 0; i < windows.size(); i++) {
 			DesktopWindow w = windows.get(i);
 			char[] textBuffer = new char[1000];
-					user32.GetClassName(w.getHWND(), textBuffer, textBuffer.length);
+			user32.GetClassName(w.getHWND(), textBuffer, textBuffer.length);
 			String className = new String(textBuffer).trim();
 			String windowTitle = w.getTitle();
 			debug("" + windowTitle + " | " + className);

--- a/src/main/java/bh/bot/common/jna/MiniClientWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/MiniClientWindowsJna.java
@@ -57,7 +57,7 @@ public class MiniClientWindowsJna extends AbstractWindowsJna {
 		if (rect.width <= 0 || rect.height <= 0)
 			return new Tuple4<>(false, "Window has minimized", null, null);
 
-		Offset offset = new Offset(rect.x, rect.y);
+		Offset offset = new Offset(rect.x, rect.y+45);
 		if (offset.X < 0 || offset.Y < 0)
 			Main.showWarningWindowMustClearlyVisible();
 

--- a/src/main/java/bh/bot/common/jna/MiniClientWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/MiniClientWindowsJna.java
@@ -14,7 +14,6 @@ import java.awt.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static bh.bot.common.Log.debug;
 import static bh.bot.common.Log.warn;
 
 public class MiniClientWindowsJna extends AbstractWindowsJna {
@@ -30,14 +29,12 @@ public class MiniClientWindowsJna extends AbstractWindowsJna {
 			user32.GetClassName(w.getHWND(), textBuffer, textBuffer.length);
 			String className = new String(textBuffer).trim();
 			String windowTitle = w.getTitle();
-			debug("" + windowTitle + " | " + className);
 			if ("Bit Heroes".equals(windowTitle)) {
 				if ("Chrome_WidgetWin_1".equals(className)) {
 					success = user32.EnumChildWindows(w.getHWND(), (hWnd, data) -> {
 						char[] innerTextBuffer = new char[1000];
 						user32.GetClassName(hWnd, innerTextBuffer, innerTextBuffer.length);
 						String innerClassName = new String(innerTextBuffer).trim();
-						debug("" + windowTitle + " | " + innerClassName);
 						if ("Chrome_RenderWidgetHostHWND".equals(innerClassName) || "Intermediate D3D Window".equals(innerClassName)) {
 							result.set(hWnd);
 							return true;

--- a/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
@@ -40,7 +40,6 @@ public class SteamWindowsJna extends AbstractWindowsJna {
 					user32.GetClassName(w.getHWND(), textBuffer, textBuffer.length);
 			String className = new String(textBuffer).trim();
 			String windowTitle = w.getTitle();
-			debug("" + windowTitle + " | " + className);
 			if ("Bit Heroes".equals(windowTitle)) {
 				if ("UnityWndClass".equals(className)) {
 					hwnd = w.getHWND();

--- a/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
@@ -3,10 +3,13 @@ package bh.bot.common.jna;
 import java.awt.Rectangle;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.List;
 
 import bh.bot.Main;
 import bh.bot.common.Configuration;
 import com.sun.jna.Pointer;
+import com.sun.jna.platform.DesktopWindow;
+import com.sun.jna.platform.WindowUtils;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.WinDef.HWND;
 import com.sun.jna.platform.win32.WinDef.RECT;
@@ -29,11 +32,21 @@ public class SteamWindowsJna extends AbstractWindowsJna {
 
 	@Override
 	public HWND getGameWindow(Object... args) {
-		HWND hwnd = user32.FindWindow("UnityWndClass", "Bit Heroes");
-		if (hwnd == null) {
-			err("Can not detect game window (Steam)!!!");
-			showErrAskIfBhRunningOrReqAdm();
-			Main.exit(Main.EXIT_CODE_WINDOW_DETECTION_ISSUE);
+		HWND hwnd = null;
+		List<DesktopWindow> windows = WindowUtils.getAllWindows(true);
+		for (int i = 0; i < windows.size(); i++) {
+			DesktopWindow w = windows.get(i);
+			char[] textBuffer = new char[1000];
+					user32.GetClassName(w.getHWND(), textBuffer, textBuffer.length);
+			String className = new String(textBuffer).trim();
+			String windowTitle = w.getTitle();
+			debug("" + windowTitle + " | " + className);
+			if ("Bit Heroes".equals(windowTitle)) {
+				if ("UnityWndClass".equals(className)) {
+					hwnd = w.getHWND();
+				}
+				break;
+			}
 		}
 		return hwnd;
 	}

--- a/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
@@ -48,6 +48,11 @@ public class SteamWindowsJna extends AbstractWindowsJna {
 				break;
 			}
 		}
+		if (hwnd == null) {
+			err("Can not detect game window (Steam)!!!");
+			showErrAskIfBhRunningOrReqAdm();
+			Main.exit(Main.EXIT_CODE_WINDOW_DETECTION_ISSUE);
+		}
 		return hwnd;
 	}
 

--- a/src/main/java/bh/bot/common/types/flags/FlagDoQuest.java
+++ b/src/main/java/bh/bot/common/types/flags/FlagDoQuest.java
@@ -1,0 +1,29 @@
+package bh.bot.common.types.flags;
+
+import bh.bot.app.AbstractApplication;
+import bh.bot.app.AfkApp;
+import bh.bot.common.types.annotations.FlagMeta;
+
+@FlagMeta(displayOrder = 1000)
+public class FlagDoQuest extends FlagPattern.NonParamFlag {
+
+	@Override
+	public String getName() {
+		return "quest";
+	}
+
+    @Override
+    public String getDescription() {
+        return "Auto doing Quest";
+    }
+
+    @Override
+    public boolean isGlobalFlag() {
+        return false;
+    }
+
+    @Override
+    public boolean internalCheckIsSupportedByApp(AbstractApplication instance) {
+        return instance instanceof AfkApp;
+    }
+}

--- a/src/main/java/bh/bot/common/types/flags/Flags.java
+++ b/src/main/java/bh/bot/common/types/flags/Flags.java
@@ -6,6 +6,7 @@ public class Flags {
             new FlagDoGvG(),
             new FlagDoInvasion(),
             new FlagDoExpedition(),
+            new FlagDoQuest(),
             new FlagDoPvp(),
             new FlagDoRaid(),
             new FlagDoTrials(),


### PR DESCRIPTION
Major: Alters JNA usage to have compatibility to find the Game Window on Windows 11, via mini-client or steam. The existing method was blocked by new UI decisions in Windows 11.
Tested on windows client, not tested on steam client (yet).

Requires windows to be specifically named "Bit Heroes" which could be problematic. I might want to make some more changes before this is ready to merge, but i wanted to put the work out in its own PR
 
Minor: Adds Missing Flag for Quest