### PR TITLE
Change hide mouse location and fix for steam

### DIFF
--- a/src/main/java/bh/bot/app/AbstractApplication.java
+++ b/src/main/java/bh/bot/app/AbstractApplication.java
@@ -1573,6 +1573,11 @@ public abstract class AbstractApplication {
 		}
 	}
 
+	protected void setGameWindowOnTop() {
+		IJna jna = getJnaInstance();
+		jna.setGameWindowOnTop(jna.getGameWindow());
+	}
+
 	protected void printRequiresSetting() {
 		err("You have to do setting before using this function");
 		err("Please launch script '%s' and follow instruction", scriptFileName("setting"));

--- a/src/main/java/bh/bot/app/AfkApp.java
+++ b/src/main/java/bh/bot/app/AfkApp.java
@@ -9,6 +9,7 @@ import bh.bot.common.exceptions.InvalidDataException;
 import bh.bot.common.exceptions.NotSupportedException;
 import bh.bot.common.types.AttendablePlace;
 import bh.bot.common.types.AttendablePlaces;
+import bh.bot.common.types.Offset;
 import bh.bot.common.types.UserConfig;
 import bh.bot.common.types.annotations.AppMeta;
 import bh.bot.common.types.annotations.RequireSingleInstance;
@@ -165,7 +166,6 @@ public class AfkApp extends AbstractApplication {
                     || (doInvasion && doExpedition);
             boolean isUnknownTrialsOrGauntlet = doTrials && doGauntlet;
             int continuousNotFound = 0;
-            final Point coordinateHideMouse = new Point(0, 0);
             final ArrayList<Tuple3<AttendablePlace, AtomicLong, List<AbstractDoFarmingApp.NextAction>>> taskList = new ArrayList<>();
             // Add Questing as first task
             if (doQuest)
@@ -318,7 +318,7 @@ public class AfkApp extends AbstractApplication {
                     debug("confirmStartNotFullTeam");
                     sendSpaceKey();
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
@@ -328,7 +328,7 @@ public class AfkApp extends AbstractApplication {
                     sleep(1_000);
                     spamEscape(1);
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
@@ -338,35 +338,35 @@ public class AfkApp extends AbstractApplication {
                     debug("mapButtonOnFamiliarUi");
                     sendEscape();
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
                 if (tryEnterRaid(doRaid, userConfig, isRaidBlocked)) {
                     debug("tryEnterRaid");
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
                 if (tryEnterQuest(doQuest, userConfig, isQuestBlocked, this.gameScreenInteractor)) {
                     debug("tryEnterQuest");
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
                 if (tryEnterWorldBoss(doWorldBoss, userConfig, isWorldBossBlocked)) {
                     debug("tryEnterWorldBoss");
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
                 if (tryEnterExpedition(doExpedition, this.expeditionPlace)) {
                     debug("tryEnterExpedition");
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
@@ -381,7 +381,6 @@ public class AfkApp extends AbstractApplication {
                                 if (p != null) {
                                     int offset = Configuration.Features.isFunctionDisabled("target-pvp") ? 0 : offsetTargetPvp;
                                     mouseMoveAndClickAndHide(new Point(p.x, p.y + offset));
-                                    moveCursor(coordinateHideMouse);
                                     continue ML;
                                 }
                             } else if (clickImage(naBtnFightPvp.image)) {
@@ -396,13 +395,12 @@ public class AfkApp extends AbstractApplication {
                         tempBlock(tuple._1);
                     }
                     continuousNotFound = 0;
-                    moveCursor(coordinateHideMouse);
+                    hideCursor();
                     continue ML;
                 }
 
                 debug("None");
                 continuousNotFound++;
-                moveCursor(coordinateHideMouse);
 
                 if (continuousNotFound >= 6) {
                     for (AbstractDoFarmingApp.NextAction nextAction : outOfTurnNextActionList) {
@@ -448,10 +446,7 @@ public class AfkApp extends AbstractApplication {
                                 }
                             }
 
-                            moveCursor(point);
-                            mouseClick();
-                            sleep(100);
-                            moveCursor(coordinateHideMouse);
+                            mouseMoveAndClickAndHide(point);
                             continuousNotFound = 0;
                             continue ML;
                         }

--- a/src/main/java/bh/bot/app/farming/AbstractDoFarmingApp.java
+++ b/src/main/java/bh/bot/app/farming/AbstractDoFarmingApp.java
@@ -5,6 +5,7 @@ import bh.bot.app.AbstractApplication;
 import bh.bot.common.Configuration;
 import bh.bot.common.Telegram;
 import bh.bot.common.types.AttendablePlace;
+import bh.bot.common.types.Offset;
 import bh.bot.common.types.UserConfig;
 import bh.bot.common.types.annotations.RequireSingleInstance;
 import bh.bot.common.types.images.BwMatrixMeta;
@@ -107,7 +108,7 @@ public abstract class AbstractDoFarmingApp extends AbstractApplication {
                 }
             }
             int continuousNotFound = 0;
-            final Point coordinateHideMouse = new Point(0, 0);
+            final Point coordinateHideMouse = new Offset(0, 0).toScreenCoordinate();
             final int mainLoopInterval = Configuration.Interval.Loop.getMainLoopInterval(getDefaultMainLoopInterval());
             final int selectFightPvp = naBtnFightOfPvp != null ? userConfig.pvpTarget : 0;
             final int offsetTargetPvp = selectFightPvp < 1 ? 0 : (selectFightPvp - 1) * Configuration.screenResolutionProfile.getOffsetDiffBetweenFightButtons();

--- a/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
+++ b/src/main/java/bh/bot/common/jna/SteamWindowsJna.java
@@ -124,16 +124,16 @@ public class SteamWindowsJna extends AbstractWindowsJna {
 				return null;
 			}
 
-			if (rect.width < ew || rect.height < eh) {
-				err(
-						String.format(
-								"(Post-Resize) JNA detect invalid screen size of Steam client! Expected %dx%d but found %dx%d",
-								ew, eh, rect.width, rect.height
-						)
-				);
-				showErrReqAdm();
-				Main.exit(Main.EXIT_CODE_WINDOW_DETECTION_ISSUE);
-			}
+			// if (rect.width < ew || rect.height < eh) {
+			// 	err(
+			// 			String.format(
+			// 					"(Post-Resize) JNA detect invalid screen size of Steam client! Expected %dx%d but found %dx%d",
+			// 					ew, eh, rect.width, rect.height
+			// 			)
+			// 	);
+			// 	showErrReqAdm();
+			// 	Main.exit(Main.EXIT_CODE_WINDOW_DETECTION_ISSUE);
+			// }
 
 			lpRectC = new RECT();
 			if (!user32.GetClientRect(hwnd, lpRectC)) {

--- a/src/main/java/bh/bot/common/utils/InteractionUtil.java
+++ b/src/main/java/bh/bot/common/utils/InteractionUtil.java
@@ -73,7 +73,9 @@ public class InteractionUtil {
 		}
 
 		public static void hideCursor() {
-			moveCursor(pHideCursor);
+			Point hidePoint = new Offset(0, 0).toScreenCoordinate();
+			debug("Mouse move cursor %d,%d", hidePoint.x, hidePoint.y);
+			moveCursor(hidePoint);
 		}
 
 		public static void clickRadioButton(int level, Point[] points, String evName) {


### PR DESCRIPTION
Updates the hide cursor location to be 0,0 offset instead of 0,0 absolute.

Also changes the mouse movement to only go to hide location when needed instead of on each loop, since focus now happens automatically for screenshots without mouse activity.

Also disables some code blocking steam on windows 11. Just removing it since its a resize check that I don't care to look into right now. If a user can't get it to work, that's on them.